### PR TITLE
Update clamav-unofficial-sigs.conf

### DIFF
--- a/clamav-unofficial-sigs.conf
+++ b/clamav-unofficial-sigs.conf
@@ -194,7 +194,7 @@ phishtank.ndb  #LOW Online and valid phishing urls from phishtank.com data feed
 # lines below.  To disable all SecuriteInfo database file downloads,
 # comment all of the following lines.
 securiteinfo_dbs="
-### Securiteinfo http://www.securiteinfo.com/services/clamav_unofficial_malwares_signatures.shtml
+### Securiteinfo https://www.securiteinfo.com/services/improve-detection-rate-of-zero-day-malwares-for-clamav.shtml
 ## REQUIRED, no not disable
 securiteinfo.ign2
 # LOW
@@ -205,15 +205,6 @@ securiteinfoascii.hdb  #LOWe Text file malwares (Perl or shell scripts, bat file
 securiteinfopdf.hdb #LOW Malwares PDF 
 # HIGH
 #spam_marketing.ndb #HIGH Spam Marketing /  spammer blacklist
-# PREMIUM
-#spam_marketing_agressif.ndb #HIGH++ Spam Marketing aggressive
-# UNKNOWN IF THESE ARE AVAILABLE
-#honeynet.hdb  #LOW Old malwares not detected 
-#securiteinfoelf.hdb #LOW Malwares ELF (Linux executables) 
-#securiteinfosh.hdb #LOW Malwares SHELL (Linux) 
-#securiteinfooffice.hdb #LOW Malwares Macros Office 
-#securiteinfodos.hdb #LOW Malwares MS-DOS 
-#securiteinfobat.hdb #LOW Malwares BAT 
 " #END SECURITEINFO DATABASES
 
 # ========================


### PR DESCRIPTION
Updated signatures for Securiteinfo.com :
deleted outdated signature files
spam_marketing_agressif.ndb does not exist. spam_marketing.ndb is available on both free and paid subscription